### PR TITLE
Add a sig for known bad SSL certificates

### DIFF
--- a/modules/signatures/bad_ssl_certs.py
+++ b/modules/signatures/bad_ssl_certs.py
@@ -1,0 +1,61 @@
+# Copyright (C) 2015 KillerInstinct
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class BadSSLCerts(Signature):
+    name = "bad_ssl_certs"
+    description = "A known bad/malicious SSL cert was accessed"
+    severity = 3
+    weight = 3
+    categories = ["network"]
+    authors = ["KillerInstinct"]
+    minimum = "1.3"
+
+    def run(self):
+        # Add manual indicators here
+        sha1_indicators = {
+            "6fc7fe77aaac09d078cb50039ec507f964082583": "Dridex C&C",
+        }
+        matches = dict()
+        # Check feeds; an ideal format has a hash and description
+        if "feeds" in self.results and self.results["feeds"]:
+            # Get the data from the pre-packaged AbuseCH SSL Feed
+            if "Bad_SSL_Certs" in self.results["feeds"]:
+                with open(self.results["feeds"]["Bad_SSL_Certs"], "r") as feedfile:
+                    data = feedfile.read().splitlines()
+                if data:
+                    # This feed has results in the form of: SHA1,Description
+                    for item in data:
+                        sha1, desc = item.split(",")
+                        # populate the indicators dict
+                        if sha1 not in sha1_indicators.keys():
+                            sha1_indicators[sha1] = desc
+
+        # Check for TLS fingerprints and then try to find a match
+        if "suricata" in self.results and self.results["suricata"]:
+            if "tls" in self.results["suricata"] and self.results["suricata"]["tls"]:
+                for shahash in self.results["suricata"]["tls"]:
+                    sha = shahash["fingerprint"].replace(":", "")
+                    if sha in sha1_indicators.keys():
+                        if sha not in matches.keys():
+                            matches[sha] = sha1_indicators[sha]
+
+        if matches:
+            for item in matches.keys():
+                self.data.append({matches[item]:item})
+            return True
+
+        return False


### PR DESCRIPTION
This requires the Suricata processing module to be enabled and optionally uses the AbuseCH 'Bad_SSL_Certs' feed module. Can easily be expanded to other feeds if they are later implimented.