### PR TITLE
Correct software case in registry key pattern

### DIFF
--- a/modules/signatures/browser_startpage.py
+++ b/modules/signatures/browser_startpage.py
@@ -24,7 +24,7 @@ class browser_startpage(Signature):
     minimum = "1.2"
 
     def run(self):
-        if self.check_write_key(pattern=".*\\\\SOFTWARE\\\\(Wow6432Node\\\\)?Microsoft\\\\Internet\\ Explorer\\\\Main\\\\Start\\ Page$", regex=True):
+        if self.check_write_key(pattern=".*\\\\Software\\\\(Wow6432Node\\\\)?Microsoft\\\\Internet\\ Explorer\\\\Main\\\\Start\\ Page$", regex=True):
             return True
 
         return False


### PR DESCRIPTION
This signature would not fire on sample 833b356a2548260558f57c5cacb3d9cf until this modification had been made as the pattern would not match SOFTWARE.