### PR TITLE
Make ek_flash work with multi-line strings

### DIFF
--- a/modules/signatures/ek_flash.py
+++ b/modules/signatures/ek_flash.py
@@ -43,5 +43,5 @@ class Flash_JS(Signature):
         else:
             buf = self.get_argument(call, "Script")
 
-        if re.match(".*allowscriptaccess[ ]*=[ ]*always.*", buf, re.IGNORECASE):
+        if re.search(".*allowscriptaccess[ ]*=[ ]*always.*", buf, re.IGNORECASE):
             return True


### PR DESCRIPTION
This fixes https://github.com/brad-accuvant/community-modified/issues/74 and is also faster than using re.match with re.MULTILINE.