### PR TITLE
Create new wildcard file search signature

### DIFF
--- a/modules/signatures/file_search.py
+++ b/modules/signatures/file_search.py
@@ -1,0 +1,21 @@
+from lib.cuckoo.common.abstracts import Signature
+
+class FileSearch(Signature):
+    name = "file_search"
+    description = "Iterates over a large number of files using a wildcard search"
+    severity = 3
+    categories = ["infostealer"]
+    authors = ["Kevin Ross"]
+    minimum = "1.2"
+
+    def run(self):
+        indicators = [
+            ".*\\\\\*\.\*$",
+            ".*\\\\\*$"
+        ]
+
+        for indicator in indicators:
+            if self.check_file(pattern=indicator, regex=True) > 15:
+                return True
+
+        return False


### PR DESCRIPTION
Seen this behaviour in ransomware and information stealing malware. And example can be seen in Pony malware MD5 1d2686ff1c20644963b17ff43645270e for instance.