### PR TITLE
Add Kaspersky.IeVirtualKeyboardPlugin check

### DIFF
--- a/modules/signatures/ek_virtualcheck.py
+++ b/modules/signatures/ek_virtualcheck.py
@@ -49,7 +49,8 @@ class Virtualcheck_JS(Signature):
                 "prl_sound",
                 "prl_prl_strg",
                 "prl_tg",
-                "prl_time"
+                "prl_time",
+                "Kaspersky.IeVirtualKeyboardPlugin"
             ]
 
         if call["api"] == "JsEval":


### PR DESCRIPTION
Add in Kaspersky.IeVirtualKeyboardPlugin. 

From RIG EK where Kaspersky.IeVirtualKeyboardPlugin visible:
(resInf[v2][v5] != 0) {var pe = resInf[v2],err = "Error Code: " + pe[v5] + "\ n";err += "Error Reason: " + pe.reason;err += "Error Line: " + pe.line;if (err.indexOf("-2147023083") > 0) {return 1;} else {return 0;}}return 0;}var tmp; try{tmp = new ActiveXObject('Kaspersky.IeVirtualKeyboardPlugin.JavascriptApi.1'); }catch(e){ tmp = false; } if (tmp || check("kl1") || check("tmactmon") || check("tmcomm") || check("tmevtmgr") || check("TMEBC32") || check("tmeext") || check("tmnciesc") || check("tmtdi") || check("vm3dmp") || check("vmusbmouse") || check("vmmouse") || check("vmhgfs") || check(/*df*/"VBoxGuest") || check(/*df*/"VBoxMouse") || check(/*df*/"VBoxSF") || check(/*df*/"VBoxVideo") ||