### PR TITLE
Create signature ransomware_fileextensions.py

### DIFF
--- a/modules/signatures/ransomware_fileextensions.py
+++ b/modules/signatures/ransomware_fileextensions.py
@@ -1,0 +1,24 @@
+from lib.cuckoo.common.abstracts import Signature
+
+class RansomwareExtensions(Signature):
+    name = "ransomware_extensions"
+    description = "Appends known ransomware file extensions to files that have been encrypted"
+    severity = 3
+    categories = ["ransomware"]
+    authors = ["Kevin Ross"]
+    minimum = "1.2"
+
+    def run(self):
+        indicators = [
+            ".*\.aaa$",
+            ".*\.abc$",
+            ".*\.ecc$",
+            ".*\.exx$",
+            ".*\.ezz$",
+        ]
+
+        for indicator in indicators:
+            if self.check_file(pattern=indicator, regex=True) > 15:
+                return True
+
+        return False


### PR DESCRIPTION
Create a signature to detect files multiple files being appended with file extensions connected to know ransomware. This is mostly just Telsa/AlphaCrypt the now.

There may be a better signature than this though but I am not sure how to go about creating it. Basically if you look over the APi calls and things like TeslaCrypt of ransomware encrypting files it will generally query (i.e NtQueryInformationFile) read (i.e NtReadFile), set the file information (NtSetInformationFile), modify/encrypt file (NtWriteFile) and then it will move the original file into the new file with an appended extension (i.e abc, ezz, exx, ecc) with MoveFileWithProgressW. It will repeat this kind of cycle over multiple files as it encrypts them.

So as I said while I am not sure how to go about creating an accurate sig based on this observation it would be better because the generally process can be seen across multiple ransomware families (that actually encrypt/modify files) and it would be more resistant to evasion (i.e just create a sample with extensions not in the list although they will be easy to add for now).