### PR TITLE
Add in stolen threattrack cert

### DIFF
--- a/modules/signatures/bad_certs.py
+++ b/modules/signatures/bad_certs.py
@@ -57,6 +57,8 @@ class BadCerts(Signature):
             "0d859141ee9a0c6e725ffe6bcfc99f3efcc3fc07",
             # Used in Dridex, BIZNES AVTOMATYKA
             "9a9c618cc8f50e9ffb24b6cc8b34858fa65e778c",
+            # Stolen ThreatTrack cert
+            "8138b44330354e413dc52af1dbfca8ba1c0f6c0a",
             ]
         if "static" in self.results:
             if "digital_signers" in self.results["static"] and self.results["static"]["digital_signers"]:


### PR DESCRIPTION
Sample MD5: fd2598e843d7c4d3d45f3038c06d8715
Reference: http://myonlinesecurity.co.uk/notice-of-appearance-in-court-js-malware/

Authenticode Cert Details:
md5_fingerprint: fa0e5483c8c95769454e24f25198a41f
cn: ThreatTrack Security, Inc.
sha1_fingerprint: 8138b44330354e413dc52af1dbfca8ba1c0f6c0a
sn: 13067645890868756024436592293902887985