### PR TITLE
Add a regex mutex detection

### DIFF
--- a/modules/signatures/banker_zeus_mutex.py
+++ b/modules/signatures/banker_zeus_mutex.py
@@ -21,9 +21,9 @@ class ZeusMutexes(Signature):
     severity = 3
     categories = ["banker"]
     families = ["zeus"]
-    authors = ["Robby Zeitfuchs"]
-    minimum = "0.5"
-    references = ["https://malwr.com/analysis/NmNhODg5ZWRkYjc0NDY0M2I3YTJhNDRlM2FlOTZiMjA/#summary_mutexes", 
+    authors = ["Robby Zeitfuchs", "KillerInstinct"]
+    minimum = "1.1"
+    references = ["https://malwr.com/analysis/NmNhODg5ZWRkYjc0NDY0M2I3YTJhNDRlM2FlOTZiMjA/#summary_mutexes",
                   "https://malwr.com/analysis/MmMwNDJlMTI0MTNkNGFjNmE0OGY3Y2I5MjhiMGI1NzI/#summary_mutexes",
                   "https://malwr.com/analysis/MzY5ZTM2NzZhMzI3NDY2YjgzMjJiODFkODZkYzIwYmQ/#summary_mutexes",
                   "https://www.virustotal.com/de/file/301fcadf53e6a6167e559c84d6426960af8626d12b2e25aa41de6dce511d0568/analysis/#behavioural-info",
@@ -33,19 +33,24 @@ class ZeusMutexes(Signature):
 
     def run(self):
         indicators = [
-            "_AVIRA_.*",                                
-            "__SYSTEM__.*",                        
-            "_LILO_.*",                                   
-            "_SOSI_.*",                                  
-            ".*MSIdent Logon",                            
-            ".*MPSWabDataAccessMutex",                    
+            "_AVIRA_.*",
+            "__SYSTEM__.*",
+            "_LILO_.*",
+            "_SOSI_.*",
+            ".*MSIdent Logon",
+            ".*MPSWabDataAccessMutex",
             ".*MPSWABOlkStoreNotifyMutex"
         ]
-            
+
         for indicator in indicators:
             match = self.check_mutex(pattern=indicator, regex=True)
             if match:
                 self.data.append({"mutex": match})
-                return True            
-        
+                return True
+
+        indicator = r"(Local|Global)\\\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\}"
+        matches = self.check_mutex(pattern=indicator, regex=True, all=True)
+        if matches and len(matches) > 10:
+            return True
+
         return False


### PR DESCRIPTION
Seems Zeus variants with HTTP based C2 adapted mutex generation similar to that of Zeus variants with P2P C2. With the HTTP versions we observed many mutex creations, so we'll just trigger based on the count of the total unique mutexes that match the pattern. Also removed a bunch of white space. Bumped version as this requires all=True