### PR TITLE
Create file modifies_bootconfig.py

### DIFF
--- a/modules/signatures/modifies_bootconfig.py
+++ b/modules/signatures/modifies_bootconfig.py
@@ -1,0 +1,26 @@
+from lib.cuckoo.common.abstracts import Signature
+
+class ModifiesBootConfig(Signature):
+    name = "modifies_boot_config"
+    description = "Attempts to modify the Boot Configuration Data file"
+    severity = 3
+    categories = ["ransomware"]
+    authors = ["Kevin Ross"]
+    minimum = "1.2"
+    evented = True
+
+    def __init__(self, *args, **kwargs):
+        Signature.__init__(self, *args, **kwargs)
+
+    filter_apinames = set(["CreateProcessInternalW","ShellExecuteExW"])
+
+    def on_call(self, call, process):
+        if call["api"] == "CreateProcessInternalW":
+            cmdline = self.get_argument(call, "CommandLine").lower()
+            if "bcdedit" in cmdline and "/set" in cmdline:
+                return True
+        elif call["api"] == "ShellExecuteExW":
+            filepath = self.get_argument(call, "FilePath").lower()
+            params = self.get_argument(call, "Parameters").lower()
+            if "bcdedit" in filepath and "/set" in params:
+                return True


### PR DESCRIPTION
Seen in cryptowall MD5 6daff56b1c5429b7460dcf836803bea3. Executed commands:

 C:\Windows\System32\lsass.exe
C:\Windows\System32\svchost.exe -k WerSvcGroup
C:\Windows\system32\vssvc.exe
C:\Windows\SysWOW64\WerFault.exe -u -p 1124 -s 308
-k netsvcs
vssadmin.exe Delete Shadows /All /Quiet
bcdedit /set {default} recoveryenabled No
bcdedit /set {default} bootstatuspolicy ignoreallfailures