### PR TITLE
Add in key for internet feature controls

### DIFF
--- a/modules/signatures/browser_security.py
+++ b/modules/signatures/browser_security.py
@@ -35,6 +35,7 @@ class BrowserSecurity(Signature):
         ".*\\\\SOFTWARE\\\\(Wow6432Node\\\\)?Microsoft\\\\Windows\\\\CurrentVersion\\\\Internet\\ Settings\\\\CertificateRevocation$",
         ".*\\\\SOFTWARE\\\\(Wow6432Node\\\\)?Microsoft\\\\Internet\\ Explorer\\\\Main\\\\NoUpdateCheck$",
         ".*\\\\SOFTWARE\\\\(Wow6432Node\\\\)?Microsoft\\\\Internet\\ Explorer\\\\Security\\\\.*",
+        ".*\\\\SOFTWARE\\\\(Wow6432Node\\\\)?Microsoft\\\\Internet\\ Explorer\\\\Main\\\\FeatureControl\\\\.*",    
         ]
 
         for indicator in reg_indicators:


### PR DESCRIPTION
Seen in Bedep. Mentioned in this blog article http://www.cyphort.com/bedeps-cousin-malvertising-and-click-fraud/

These keys are all relative to general browser security. Details on what they do are here:
https://msdn.microsoft.com/en-us/library/ee330729%28v=vs.85%29.aspx