### PR TITLE
Add indicator no edit time on macro docs

### DIFF
--- a/modules/signatures/office_macro.py
+++ b/modules/signatures/office_macro.py
@@ -76,5 +76,13 @@ class Office_Macro(Signature):
                         self.severity = 3
                         self.weight += 2
                         self.description += " The file also appears to have no content."
-
+        # Increase severity on documents with no edit time containing macros indicative of auto-created documents such as by the Bartalex Kit.
+            if "Metadata" in self.results["static"]:
+                if "SummaryInformation" in self.results["static"]["Metadata"]:
+                    time = self.results["static"]["Metadata"]["SummaryInformation"]["total_edit_time"]
+                    if time == "0":
+                        self.severity = 3
+                        self.weight += 2
+                        self.description += " The file also appears to have no edit time."
+                        
         return ret


### PR DESCRIPTION
Add in indicator for office document containing macros but no edit time seen in Bartalex created documents (i.e Dridex). 

I am not convinved though on the way this ends up in text. For instance the MD5 facec082a3cffddc43e668a3080487f5 from yesterday results in a severity 3 message of "The office file has 3 macros. The file also appears to have no edit time". In today's dridex document MD5 7d3d5d9a10053587ac981f85c18d0e8a the message becomes "The office file has 3 macros. The file also appears to have no content. The file also appears to have no edit time" which sounds too much of a listing and does not read particularly well but detection wise it is fine.