### PR TITLE
Add sig for adding a windows firewall exception

### DIFF
--- a/modules/signatures/modifies_windows_firewall.py
+++ b/modules/signatures/modifies_windows_firewall.py
@@ -1,0 +1,26 @@
+from lib.cuckoo.common.abstracts import Signature
+
+class ModifiesWindowsFirewall(Signature):
+    name = "modifies_windows_firewall"
+    description = "Attempts to create a Windows firewall exception"
+    severity = 3
+    categories = ["network"]
+    authors = ["Kevin Ross"]
+    minimum = "1.2"
+    evented = True
+
+    def __init__(self, *args, **kwargs):
+        Signature.__init__(self, *args, **kwargs)
+
+    filter_apinames = set(["CreateProcessInternalW","ShellExecuteExW"])
+
+    def on_call(self, call, process):
+        if call["api"] == "CreateProcessInternalW":
+            cmdline = self.get_argument(call, "CommandLine").lower()
+            if "netsh.exe" in cmdline and "firewall" in cmdline and "action=allow" in cmdline:
+                return True
+        elif call["api"] == "ShellExecuteExW":
+            filepath = self.get_argument(call, "FilePath").lower()
+            params = self.get_argument(call, "Parameters").lower()
+            if "netsh.exe" in filepath and "firewall" in params and "action=allow" in params:
+                return True


### PR DESCRIPTION
Seen for example in sample MD5 3251e5ebe7c0e61aac2d2f74b3423e12

"C:\Windows\system32\netsh.exe" advfirewall firewall set rule name="Core Networking - System IP Core" dir=in new action=allow enable=yes profile=any
"C:\Windows\system32\netsh.exe" advfirewall firewall add rule name="Core Networking - System IP Core" dir=in action=allow enable=yes profile=any
"C:\Windows\system32\netsh.exe" advfirewall firewall set rule name="Core Networking - System IP Core" dir=out new action=allow enable=yes profile=any
"C:\Windows\system32\netsh.exe" advfirewall firewall add rule name="Core Networking - System IP Core" dir=out action=allow enable=yes profile=any