### PR TITLE
Add new detections into office_macro

### DIFF
--- a/modules/signatures/office_macro.py
+++ b/modules/signatures/office_macro.py
@@ -93,6 +93,6 @@ class Office_Macro(Signature):
                     if author == "1" or author == "Alex" or author == "Microsoft Office":
                         self.severity = 3
                         self.weight += 2
-                        self.data.append({"author" : "The file appears to have been created by a fake author indicative of an automated document creation kit."})
+                        self.data.append({"author" : "The file appears to have been created by a known fake author indicative of an automated document creation kit."})
 
         return ret

--- a/modules/signatures/office_macro.py
+++ b/modules/signatures/office_macro.py
@@ -67,7 +67,7 @@ class Office_Macro(Signature):
                 for positive in positives:
                     self.data.append({"Lure": positive})
 
-        # Increase severity on empty documents with macros
+        # Increase severity on office documents with suspicious characteristics
         if ret and "static" in self.results and "office" in self.results["static"]:
             if "Metadata" in self.results["static"]["office"]:
                 if "SummaryInformation" in self.results["static"]["office"]["Metadata"]:
@@ -75,6 +75,24 @@ class Office_Macro(Signature):
                     if words == "0":
                         self.severity = 3
                         self.weight += 2
-                        self.description += " The file also appears to have no content."
+                        self.data.append({"content" : "The file appears to have no content."})
+
+        if ret and "static" in self.results and "office" in self.results["static"]:
+            if "Metadata" in self.results["static"]["office"]:
+                if "SummaryInformation" in self.results["static"]["office"]["Metadata"]:
+                    time = self.results["static"]["office"]["Metadata"]["SummaryInformation"]["total_edit_time"]
+                    if time == "0":
+                        self.severity = 3
+                        self.weight += 2
+                        self.data.append({"edit_time" : "The file appears to have no edit time."})
+
+        if ret and "static" in self.results and "office" in self.results["static"]:
+            if "Metadata" in self.results["static"]["office"]:
+                if "SummaryInformation" in self.results["static"]["office"]["Metadata"]:
+                    author = self.results["static"]["office"]["Metadata"]["SummaryInformation"]["author"]
+                    if author == "1" or author == "Alex" or author == "Microsoft Office":
+                        self.severity = 3
+                        self.weight += 2
+                        self.data.append({"author" : "The file appears to have been created by a fake author indicative of a automated document creation kit."})
 
         return ret

--- a/modules/signatures/office_macro.py
+++ b/modules/signatures/office_macro.py
@@ -93,6 +93,6 @@ class Office_Macro(Signature):
                     if author == "1" or author == "Alex" or author == "Microsoft Office":
                         self.severity = 3
                         self.weight += 2
-                        self.data.append({"author" : "The file appears to have been created by a fake author indicative of a automated document creation kit."})
+                        self.data.append({"author" : "The file appears to have been created by a fake author indicative of an automated document creation kit."})
 
         return ret


### PR DESCRIPTION
Add in detections for known malicious authors & edit time as well as modifications to append date. This means for an office document with macros the main message will always be "The office file has X macros" as either a severity 2 or 3 depending if this is modified. 

I did want to do self.description += " The file also appears to contain suspicious characteristics." so that when either of these detected it would tag that onto the main message. However I was uncertain at the time how to make it so that it would only append this to the end once even if multiple hits fired.