### PR TITLE
Update office macro sig

### DIFF
--- a/modules/signatures/office_macro.py
+++ b/modules/signatures/office_macro.py
@@ -72,7 +72,7 @@ class Office_Macro(Signature):
             if "Metadata" in self.results["static"]["office"]:
                 if "SummaryInformation" in self.results["static"]["office"]["Metadata"]:
                     words = self.results["static"]["office"]["Metadata"]["SummaryInformation"]["num_words"]
-                    if words == "0":
+                    if words == "0" or words == "None":
                         self.severity = 3
                         self.weight += 2
                         self.data.append({"content" : "The file appears to have no content."})
@@ -81,10 +81,19 @@ class Office_Macro(Signature):
             if "Metadata" in self.results["static"]["office"]:
                 if "SummaryInformation" in self.results["static"]["office"]["Metadata"]:
                     time = self.results["static"]["office"]["Metadata"]["SummaryInformation"]["total_edit_time"]
-                    if time == "0":
+                    if time == "0" or time == "None":
                         self.severity = 3
                         self.weight += 2
                         self.data.append({"edit_time" : "The file appears to have no edit time."})
+                        
+        if ret and "static" in self.results and "office" in self.results["static"]:
+            if "Metadata" in self.results["static"]["office"]:
+                if "SummaryInformation" in self.results["static"]["office"]["Metadata"]:
+                    pages = self.results["static"]["office"]["Metadata"]["SummaryInformation"]["num_pages"]
+                    if pages == "0" or pages == "None":
+                        self.severity = 3
+                        self.weight += 2
+                        self.data.append({"no_pages" : "The file appears to have no pages potentially caused by it being malformed or intentionally corrupted"})
 
         if ret and "static" in self.results and "office" in self.results["static"]:
             if "Metadata" in self.results["static"]["office"]:


### PR DESCRIPTION
Add in detections where edit time instead of being 0 is None, same also for number of words. Also added in a new detection for the same thing with number of pages. 

This has been seen in recent Dridex emails (i.e MD5 07010709d3a84b41e1367adb3ea3dac8) where only parts that fire from this was that it had 4 macros and it was a known malicious auto-generated author ("1").